### PR TITLE
Peer tries to become host if host disconnects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,9 @@ bin/lanchat: main.go config.go ui/*.go lan/*.go logger/*.go
 
 .PHONY: test
 test:
-	go test -race ./...
+	@go test -race ./...
 
 .PHONY: check
 check: bin/lanchat
 	@./fake_chat.sh
 
-.PHONY: test
-test:
-	@go test -race ./...

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Run `./lanchat -h` to see available flags. Besides command line flags, options c
 
 The program automatically detects if there's already a running _Lanchat_ server in the local network and connects to it. If there isn't, the command starts one on port _6776_.
 
-Start typing to chat, or run one of the available commands (enter `:h` to see a list).
+Start typing to chat, or run one of the available commands (enter `:help` to see what these are).
 
 ### Build from source
 
@@ -30,10 +30,14 @@ Download repository and run `make`.
 - [x] Fix handling of :id command: change own label
 - [x] Transmit administrative messages to all peers (e.g. "user 'bla' connected")
 - [x] Add notifications with a cooldown
-- [ ] Tests
 - [x] Configuration file
-- [ ] Become host if previous host disconnects; ping peers periodically
-- [ ] Add :help (and :h) command
+- [x] Become host if previous host disconnects; ping peers periodically
+- [x] Add :help command
+- [ ] Every peer should know about all others, not just the host.
+- [ ] Use peer information to make host reelection more reliable
+- [ ] Show current peers with :info
+- [ ] Show currently connected peers on a side tab
+- [ ] More tests
 
 ## Testing
 
@@ -58,9 +62,10 @@ A filepath can be passed to _lanchat_ for configuration with:
 Below is an example TOML:
 
 ```toml
-username = icarus # default 'noone'
-port = 6777       # default 6776
-local = true      # default false
-notify = false    # default true
+username = "icarus" # default 'noone'
+port = 6777         # default 6776
+local = true        # default false
+notify = false      # default true
+force-host = true   # default false
 ```
 

--- a/lan/scan.go
+++ b/lan/scan.go
@@ -111,7 +111,7 @@ func (s *DefaultScanner) scanHost(ips []string, chatPort int) (string, bool) {
 	}
 
 	hostInCh := make(chan string)
-	logger.Infof("Scanning %d hosts\n", len(ips))
+	logger.Debugf("Scanning %d hosts\n", len(ips))
 	go func(ch chan string) {
 		for _, host := range ips {
 			hostInCh <- host

--- a/main.go
+++ b/main.go
@@ -22,12 +22,13 @@ func main() {
 		scanner = &lan.DefaultScanner{Local: cfg.local}
 
 	}
-	client := &lan.Client{Name: cfg.username, HostPort: cfg.port, FromUI: fromUI, ToUI: toUI, Scanner: scanner}
-	ctx, cancel := context.WithCancel(context.Background())
-	client.Start(ctx)
 	logger.Infof("Starting UI\n")
 	renderer := ui.New(cfg.username, toUI, fromUI)
 	logger.Init(&renderer)
+
+	client := &lan.Client{Name: cfg.username, HostPort: cfg.port, FromUI: fromUI, ToUI: toUI, Scanner: scanner}
+	ctx, cancel := context.WithCancel(context.Background())
+	client.Start(ctx)
 	renderer.Run()
 
 	cancel()


### PR DESCRIPTION
Once the host disconnects, peers restart the scan and can try to become hosts if no others are found. Every peer pings their known peers to find out whether they're still connected.

One important improvement is needed though. Once the host disconnects, several peers may compete to become a host. This is currently dealt with by adding a random sleep between the time they notice the host has disconnected and a new scan. This is of course not reliable, and different peers may still independently become hosts.

A proper way to deal with this would be to have each peer know about all others (currently the host knows about all peers, but all non-host peers only know about the host). If, for example, the host assigns some monotonically increasing ID to each peer, the one with the smallest value in the pool can have precedence in becoming the new host. That is only possible if each peer knows the identifier of all others.