### PR TITLE
Log debug entries to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lanchat
 .vscode
 bin/
+*.log

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -14,13 +14,13 @@ var (
 )
 
 const (
-	logLevelErr = iota
-	logLevelWarn
-	logLevelInfo
-	logLevelDebug
+	LogLevelErr = iota
+	LogLevelWarn
+	LogLevelInfo
+	LogLevelDebug
 )
 
-const LogLevel = logLevelInfo
+const LogLevel = LogLevelInfo
 
 func init() {
 	out := os.Stdout
@@ -31,56 +31,59 @@ func init() {
 }
 
 func Init(w io.Writer) {
-	debugLogger = log.New(w, "[D]", log.Ldate|log.Ltime|log.Lshortfile)
-	infoLogger = log.New(w, "[I]", log.Ldate|log.Ltime)
-	warnLogger = log.New(w, "[W]", log.Ldate|log.Ltime)
-	errLogger = log.New(w, "[E]", log.Ldate|log.Ltime)
+	infoLogger.SetOutput(w)
+	warnLogger.SetOutput(w)
+	errLogger.SetOutput(w)
+}
+
+func InitDebug(w io.Writer) {
+	debugLogger.SetOutput(w)
 }
 
 func Debug(msg string) {
-	if LogLevel >= logLevelDebug {
+	if LogLevel >= LogLevelDebug {
 		debugLogger.Print(msg)
 	}
 }
 
 func Debugf(format string, v ...interface{}) {
-	if LogLevel >= logLevelDebug {
+	if LogLevel >= LogLevelDebug {
 		debugLogger.Printf(format, v...)
 	}
 }
 
 func Info(msg string) {
-	if LogLevel >= logLevelInfo {
+	if LogLevel >= LogLevelInfo {
 		infoLogger.Print(msg)
 	}
 }
 
 func Infof(format string, v ...interface{}) {
-	if LogLevel >= logLevelInfo {
+	if LogLevel >= LogLevelInfo {
 		infoLogger.Printf(format, v...)
 	}
 }
 
 func Warn(msg string) {
-	if LogLevel >= logLevelWarn {
+	if LogLevel >= LogLevelWarn {
 		warnLogger.Print(msg)
 	}
 }
 
 func Warnf(format string, v ...interface{}) {
-	if LogLevel >= logLevelWarn {
+	if LogLevel >= LogLevelWarn {
 		warnLogger.Printf(format, v...)
 	}
 }
 
 func Error(msg string) {
-	if LogLevel >= logLevelErr {
+	if LogLevel >= LogLevelErr {
 		errLogger.Print(msg)
 	}
 }
 
 func Errorf(format string, v ...interface{}) {
-	if LogLevel >= logLevelErr {
+	if LogLevel >= LogLevelErr {
 		errLogger.Printf(format, v...)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/MarcPer/lanchat/lan"
 	"github.com/MarcPer/lanchat/logger"
@@ -25,6 +27,9 @@ func main() {
 	logger.Infof("Starting UI\n")
 	renderer := ui.New(cfg.username, toUI, fromUI)
 	logger.Init(&renderer)
+	f := debugFile()
+	defer f.Close()
+	logger.InitDebug(f)
 
 	client := &lan.Client{Name: cfg.username, HostPort: cfg.port, FromUI: fromUI, ToUI: toUI, Scanner: scanner}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -33,4 +38,19 @@ func main() {
 
 	cancel()
 	fmt.Println("bye")
+}
+
+func debugFile() *os.File {
+	var debugPath string
+	if logger.LogLevel >= logger.LogLevelDebug {
+		debugPath = "debug.log"
+	} else {
+		debugPath = os.DevNull
+	}
+
+	f, err := os.OpenFile(debugPath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return f
 }


### PR DESCRIPTION
Debug log entries are now logged to a file (`debug.log`), if log level is DEBUG. There are two reasons for this:
- it's useful to see debug entries even after the application is closed;
- the previous implementation always sent the text to the UI and immediately flushed it. Having to sync with the UI became a bottleneck which, for example, made the host scanning extremely slow whenever debug logs were active.

It might be useful to allow the log file path to be set by configuration (and perhaps even the log level too). This will be implemented if it becomes necessary.